### PR TITLE
added .editorconfig for ktlint to ignore the max line length rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+insert_final_newline=true
+max_line_length=off


### PR DESCRIPTION
Added an .editorconfig file at root in order to ignore ktlint's max line length rule